### PR TITLE
Fixing dockerfile install and chpassword line

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,11 @@
 FROM debian:latest
 
 RUN apt update
-RUN apt install -y openssh-server sudo screen vim-nox openfortivpn dnsmasq net-tools \
-                   inetutils-ping lsof wget curl telnet dnsutils screen vim-nox \
-                   openfortivpn dnsmasq
+RUN apt install -y openssh-server sudo screen vim-nox openfortivpn dnsmasq net-tools inetutils-ping lsof wget curl telnet dnsutils
 RUN useradd -rm -d /home/<username> -s /bin/bash -g root -G sudo -u 1000 <username>
 RUN usermod -aG sudo <username>
 RUN service ssh start
-RUN echo '<somepass>:<somepass>' | chpasswd
+RUN echo '<username>:<somepass>' | chpasswd
 
 COPY Container-dnsmasq.conf /etc/
 COPY openfortivpn.config /etc/openfortivpn/config


### PR DESCRIPTION
There were several duplicates in the dockerfile which I removed. 
Also the chpasswd argument was incorrect, new one works. 